### PR TITLE
Make "Build Branch" trigger when branch is created or changed

### DIFF
--- a/.github/workflows/build-updatesite-branches.yml
+++ b/.github/workflows/build-updatesite-branches.yml
@@ -5,9 +5,10 @@ name: Build Branch
 
 on:
   push:
-    branches:
-      - /refs/heads/*
-      - !master
+    branches-ignore:
+      - master
+    tags-ignore:
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes the missing workflow-triggers when you push to a non-master branch.
Also, this adds a trigger to run the workflow whenever you create a new branch.

To setup the triggers, I used the [Github workflow reference](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags).

I tested both triggers on my fork.

#### Known Problems
When you create a new branch, the "Build Branch" workflow is triggers twice at the same time:
- one for a "push" event
- one for a "create" event

I spent approx 1h on the problem but could not find a solution to this.
@AObuchow If you find some hint, pls let me know.
