### PR TITLE
Make updatesite workflow use actual Github actor instead of 'Github Action'

### DIFF
--- a/.github/workflows/build-updatesite-branches.yml
+++ b/.github/workflows/build-updatesite-branches.yml
@@ -32,6 +32,8 @@ jobs:
         uses: ingomohr/push-p2-repo-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          git-user: ${{ github.actor}}
+          git-email: ${{ github.actor}}@users.noreply.github.com
           path-to-p2-repo-created-by-maven: 'releng-updatesite/target'
           path-to-p2-repo-target: 'updatesite'
           commit-message: 'add new updatesite'

--- a/.github/workflows/build-updatesite-master.yml
+++ b/.github/workflows/build-updatesite-master.yml
@@ -26,6 +26,8 @@ jobs:
         uses: ingomohr/push-p2-repo-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          git-user: ${{ github.actor}}
+          git-email: ${{ github.actor}}@users.noreply.github.com
           path-to-p2-repo-created-by-maven: 'releng-updatesite/target'
           path-to-p2-repo-target: 'updatesite'
           commit-message: 'add new updatesite'


### PR DESCRIPTION
As @PyvesB noted in [this discussion](https://github.com/AObuchow/Eclipse-Spectrum-Theme/pull/58#discussion_r456888757), we can change the build jobs for master and all other branches to use the actual Github actor instead of "Github Action" (which links an organization).

So, w/ this PR we do just that.

<img width="270" alt="Screenshot 2020-07-19 at 13 15 13" src="https://user-images.githubusercontent.com/2838592/87873438-ed941f00-c9c1-11ea-800a-cf97825a8301.png">

The new settings resolve to the actual user, so that the link on the Github UI can be used to jump to that user in Github.

In the commit, the author/committer info would look like this (for my fork):

<img width="672" alt="Screenshot 2020-07-19 at 13 17 37" src="https://user-images.githubusercontent.com/2838592/87873499-4c599880-c9c2-11ea-900b-60e6e2e75342.png">
