### PR TITLE
Make Github Workflow Push Updatesite Again

### DIFF
--- a/.github/workflows/build-updatesite-branches.yml
+++ b/.github/workflows/build-updatesite-branches.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Push Updatesite
-        uses: ingomohr/push-p2-repo-action@v1
+        uses: ingomohr/push-p2-repo-action@v1_0_1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git-user: ${{ github.actor}}

--- a/.github/workflows/build-updatesite-master.yml
+++ b/.github/workflows/build-updatesite-master.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Push Updatesite
-        uses: ingomohr/push-p2-repo-action@v1
+        uses: ingomohr/push-p2-repo-action@v1_0_1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git-user: ${{ github.actor}}


### PR DESCRIPTION
Tonight I noticed that my workflows always failed with an unwanted char in some line of my "push updatesite" yaml script.

Since the script is used via a Git tag, and I didn't change the tag nor the commit, I assume that Github changed the check-behavior.
I fixed the script and added a new tag "v1_0_1".

This PR updates the workflows for branch and master to use the new version of the "push updatesite" Github action.

Tested on my fork. Worked as expected.